### PR TITLE
Scraps the Handle class in favour of using Value& to toss references around for AssignmentStatements

### DIFF
--- a/AST.cpp
+++ b/AST.cpp
@@ -986,7 +986,7 @@ Value GlobalAccess::resolve(Interpreter& interp)
 
 Value& GlobalAccess::handle(Interpreter& interp)
 {
-	return interp.get_global(var, this);
+	return *interp.has_global(var, this);
 }
 
 

--- a/AST.cpp
+++ b/AST.cpp
@@ -598,7 +598,7 @@ Value CallExpression::resolve(Interpreter& interp)
 	Object* obj = fptr->get_obj();
 	if (obj)
 	{
-		return obj->call_method(interp, fptr->get_name(), vargs);
+		return obj->call_method(interp, Directory::lastword(fptr->get_name()), vargs);
 	}
 
 	fptr->give_args(interp, vargs);
@@ -802,7 +802,14 @@ Value& MemberAccess::handle(Interpreter& interp) // Tons of similar code to Memb
 	{
 		Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(back)->get_str());
 		if (v) return *v;
-		return *(new Value(fr.t_value.as_object_ptr->get_method(interp, static_cast<Identifier*>(back)->get_str())));
+		Function* meth = fr.t_value.as_object_ptr->get_method(interp, static_cast<Identifier*>(back)->get_str());
+		if (!meth)
+		{
+			interp.RuntimeError(this, "MemberAccess failed because member does not exist!");
+			return *(new Value(Value::vType::Null, 1));
+		}
+		meth->set_obj(fr.t_value.as_object_ptr);
+		return *(new Value(meth));
 	}
 
 	// This is something confusing, then

--- a/AST.cpp
+++ b/AST.cpp
@@ -8,6 +8,9 @@
 #define BIN_ENUMS(a,b,c) ( (uint32_t(a) << 16) | (uint32_t(b) << 8)  | uint32_t(c) )
 #define UN_ENUMS(a,b) ((uint32_t(a) << 8)  | uint32_t(b) )
 
+
+Value Value::dev_null = Value();
+
 std::string Value::to_string()
 {
 	switch (t_vType)
@@ -68,7 +71,7 @@ Value ASTNode::const_resolve(Parser& parse, bool loudfail)
 Value& ASTNode::handle(Interpreter& interp)
 {
 	interp.RuntimeError(this, "Attempted to turn " + class_name() + " into a variable handle!");
-	return *(new Value(Value::vType::Null, 1));; // Memory leak woooo
+	return Value::dev_null; // Memory leak woooo
 }
 
 
@@ -114,11 +117,6 @@ Value AssignmentStatement::resolve(Interpreter& interp)
 
 	Value& lhs_val = id->handle(interp);
 
-
-	if (lhs_val.t_vType == Value::vType::Null && lhs_val.t_value.as_int == 1)
-	{
-		return Value();
-	}
 	if (lhs_val.t_vType == Value::vType::Function)
 	{
 		std::cout << "WARNING: Overwriting a Value which stores a function pointer!\n";
@@ -796,7 +794,7 @@ Value& MemberAccess::handle(Interpreter& interp) // Tons of similar code to Memb
 	if (fr.t_vType != Value::vType::Object)
 	{
 		interp.RuntimeError(this, "Attempted to do MemberAccess on non-Object Value!");
-		return *(new Value(Value::vType::Null, 1));
+		return Value::dev_null;
 	}
 	if (back->class_name() == "Identifier")
 	{
@@ -806,7 +804,7 @@ Value& MemberAccess::handle(Interpreter& interp) // Tons of similar code to Memb
 		if (!meth)
 		{
 			interp.RuntimeError(this, "MemberAccess failed because member does not exist!");
-			return *(new Value(Value::vType::Null, 1));
+			return Value::dev_null;
 		}
 		meth->set_obj(fr.t_value.as_object_ptr);
 		return *(new Value(meth));
@@ -814,7 +812,7 @@ Value& MemberAccess::handle(Interpreter& interp) // Tons of similar code to Memb
 
 	// This is something confusing, then
 	interp.RuntimeError(this, "Unimplemented MemberAccess with second operand of type " + back->class_name() + "!");
-	return *(new Value(Value::vType::Null, 1));
+	return Value::dev_null;
 }
 
 std::unordered_map<std::string, Value> ClassDefinition::resolve_properties(Parser& parse)
@@ -860,7 +858,7 @@ Value& ParentAccess::handle(Interpreter& interp)
 	if (!o)
 	{
 		interp.RuntimeError(this, "Cannot do ParentAccess in classless function!");
-		return *(new Value(Value::vType::Null, 1));
+		return Value::dev_null;
 	}
 
 	return *(o->has_property(interp,prop));

--- a/AST.cpp
+++ b/AST.cpp
@@ -65,16 +65,10 @@ Value ASTNode::const_resolve(Parser& parse, bool loudfail)
 	return Value();
 }
 
-Handle ASTNode::handle(Interpreter& interp)
+Value& ASTNode::handle(Interpreter& interp)
 {
 	interp.RuntimeError(this, "Attempted to turn " + class_name() + " into a variable handle!");
-	return Handle();
-}
-
-Handle ASTNode::const_handle(Parser& parse)
-{
-	parse.ParserError(nullptr, "Attempted to const_handle() an abstract ASTNode! (Type:" + class_name() + ")");
-	return Handle();
+	return *(new Value(Value::vType::Null, 1));; // Memory leak woooo
 }
 
 
@@ -97,16 +91,19 @@ Value Identifier::resolve(Interpreter& interp)
 	return interp.get_var(t_name,this);
 }
 
-Handle Identifier::handle(Interpreter& interp)
+Value& Identifier::handle(Interpreter& interp)
 {
 	//We actually have to evaluate here whether or not the identifier present is pointing to a function or not, at the current scope.
 
-	Handle hndl;
-	hndl.type = Handle::HType::Name;
-	hndl.name = t_name;
-	hndl.is_function = interp.get_func(t_name,this,false);
-
-	return hndl;
+	Function* funky = interp.get_func(t_name,this,false);
+	if (funky)
+	{
+		return *(new Value(funky)); // memory leak woo
+	}
+	else
+	{
+		return interp.get_var(t_name, this);
+	}
 }
 
 
@@ -115,102 +112,22 @@ Value AssignmentStatement::resolve(Interpreter& interp)
 {
 	Value rhs_val = rhs->resolve(interp);
 
+	Value& lhs_val = id->handle(interp);
 
-	//std::cout << "Their name is " + id->get_str() + " and their value is " + std::to_string(rhs_val.t_value.as_int) + "\n";
 
-	/*
+	if (lhs_val.t_vType == Value::vType::Null && lhs_val.t_value.as_int == 1)
+	{
+		return Value();
+	}
+	if (lhs_val.t_vType == Value::vType::Function)
+	{
+		std::cout << "WARNING: Overwriting a Value which stores a function pointer!\n";
+	}
+
 	//While we do know our own assignment, we don't actually use that information in the AST (as of 7th May 2021)
 	//That's assumed to be handled by the parser.
-	if (t_op != aOps::Assign)
-	{
-		interp.RuntimeError(this, "Attempt to call unimplemented Assignment operation: " + std::to_string(static_cast<int>(t_op)));
-		return rhs_val;
-	}
-	*/
 
-	//FIXME: This should really just be a switch statement.
-	if (id->class_name() == "Identifier")
-	{
-		Identifier* idfr = static_cast<Identifier*>(id);
-		interp.override_var(idfr->get_str(), rhs_val, this);
-	}
-	else if (id->class_name() == "GlobalAccess")
-	{
-		interp.set_global(static_cast<GlobalAccess*>(id)->var, rhs_val, this);
-	}
-	else if (id->class_name() == "ParentAccess")
-	{
-		interp.set_property(static_cast<ParentAccess*>(id)->prop, rhs_val, this);
-	}
-	else if (id->class_name() == "MemberAccess" || id->class_name() == "IndexAccess")
-	{
-		Handle hndl = id->handle(interp);
-		Object* objptr;
-
-		switch (hndl.type)
-		{
-		case(Handle::HType::Obj):
-			objptr = hndl.data.obj;
-			break;
-		case(Handle::HType::Name):
-		{
-			Value val = interp.get_var(hndl.name, this);
-			if (val.t_vType != Value::vType::Object)
-			{
-				interp.RuntimeError(this, "Cannot acquire member of non-object Value!");
-				return Value();
-			}
-			objptr = val.t_value.as_object_ptr;
-			break;
-		}
-		case(Handle::HType::Global):
-		{
-			Value val = interp.get_global(hndl.name, this);
-			if (val.t_vType != Value::vType::Object)
-			{
-				interp.RuntimeError(this, "Cannot acquire member of non-object global Value!");
-				return Value();
-			}
-			objptr = val.t_value.as_object_ptr;
-			break;
-		}
-		case(Handle::HType::Parent):
-		{
-			Value val = interp.get_property(hndl.name, this);
-			if (val.t_vType != Value::vType::Object)
-			{
-				interp.RuntimeError(this, "Cannot acquire member of non-object global Value!");
-				return Value();
-			}
-			objptr = val.t_value.as_object_ptr;
-			break;
-		}
-		default:
-			interp.RuntimeError(this, "Unknown Handle type returned during MemberAccess!");
-			return Value();
-		}
-
-		if(id->class_name() == "MemberAccess")
-			objptr->set_property(interp, hndl.name, rhs_val);
-		else // IndexAccess
-		{
-			if (objptr->is_table())
-			{
-				if (hndl.index == -1)
-					static_cast<Table*>(objptr)->at_set(interp, Value(hndl.name), rhs_val);
-				else
-					static_cast<Table*>(objptr)->at_set(interp, Value(hndl.index), rhs_val);
-			}
-			else
-			{
-				objptr->set_property(interp, hndl.name, rhs_val);
-			}
-		}
-	}
-	else
-	{
-		interp.RuntimeError(this, "Unknown or underimplemented handleable ASTNode found at runtime!");
-	}
+	lhs_val = rhs_val;
 
 	return rhs_val; // If anything.
 }
@@ -288,13 +205,7 @@ Value UnaryExpression::resolve(Interpreter& interp)
 std::pair<std::string, Value> LocalAssignmentStatement::resolve_property(Parser& parser)
 {
 	//step 1. get string
-	Handle huh = id->const_handle(parser);
-
-	if (huh.type != Handle::HType::Name)
-		parser.ParserError(nullptr, "Illegitimate Handle given for property in class definition!");
-
-	std::string suh = huh.name;
-	huh.qdel();
+	std::string suh = static_cast<Identifier*>(id)->get_str();
 
 	//step 2. get value
 	Value ruh = rhs->const_resolve(parser, true);
@@ -669,13 +580,14 @@ Value Function::resolve(Interpreter & interp)
 
 Value CallExpression::resolve(Interpreter& interp)
 {
-	Handle hndl = func_expr->handle(interp);
-	if (!hndl.is_function)
+	Value func = func_expr->handle(interp);
+	if (func.t_vType != Value::vType::Function)
 	{
 		interp.RuntimeError(this, "Attempted to call something that isn't a function or method!");
 		return Value();
 	}
 
+	Function* fptr = func.t_value.as_function_ptr;
 	std::vector<Value> vargs;
 	for (auto it = args.begin(); it != args.end(); ++it)
 	{
@@ -683,21 +595,14 @@ Value CallExpression::resolve(Interpreter& interp)
 		vargs.push_back(e->resolve(interp));
 	}
 
-	if (hndl.type == Handle::HType::Name) // locally-scopped function call
+	Object* obj = fptr->get_obj();
+	if (obj)
 	{
-		Function* ourfunc = interp.get_func(hndl.name, this);
-		ourfunc->give_args(interp, vargs);
-		return ourfunc->resolve(interp);
-	}
-	else if (hndl.type == Handle::HType::Obj) // Call to a specific object
-	{
-		Object* obj = hndl.data.obj;
-		return obj->call_method(interp, hndl.name, vargs);
+		return obj->call_method(interp, fptr->get_name(), vargs);
 	}
 
-	
-	interp.RuntimeError(this, "Failed to execute CallExpression!");
-	return Value();
+	fptr->give_args(interp, vargs);
+	return fptr->resolve(interp);
 }
 
 Value NativeFunction::resolve(Interpreter& interp)
@@ -866,139 +771,52 @@ Value BreakStatement::resolve(Interpreter& interp)
 
 Value MemberAccess::resolve(Interpreter& interp)
 {
-	Handle fr = front->handle(interp);
+	Value& fr = front->handle(interp);
 	
+	if (fr.t_vType != Value::vType::Object)
+	{
+		interp.RuntimeError(this, "Attempted to do MemberAccess on non-Object Value!");
+		return Value();
+	}
+
 	//Has to always be a plain string handle
-	Handle bk = back->handle(interp);
 
-	if (bk.type != Handle::HType::Name)
+	if (back->class_name() != "Identifier")
 	{
-		interp.RuntimeError(this, "Cannot do MemberAccess with non-string property name!");
-		return Value();
-	}
-	if (bk.is_function)
-	{
-		interp.RuntimeError(this, "MemberAccess cannot return Function pointers in this implementation!"); // Soon.
-		return Value();
-	}
-	if (fr.is_function)
-	{
-		interp.RuntimeError(this, "Illegal attempt to access members of a function or method!");
+		interp.RuntimeError(this, "Cannot access non-identifier member from Object!");
 		return Value();
 	}
 
-	switch (fr.type)
-	{
-	default:
-		interp.RuntimeError(this, "Unknown or underimplemented HandleType used during MemberAccess!");
-	case(Handle::HType::Invalid):
-		return Value();
-	case(Handle::HType::Name):
-	{
-		Value vuh = interp.get_var(fr.name, this);
-		if (vuh.t_vType != Value::vType::Object)
-		{
-			interp.RuntimeError(this, "Cannot access method of non-object Value!");
-			return Value();
-		}
-		return vuh.t_value.as_object_ptr->get_property(interp, bk.name);
-	}
-	case(Handle::HType::Global):
-	{
-		Value vuh = interp.get_global(fr.name, this);
-		if (vuh.t_vType != Value::vType::Object)
-		{
-			interp.RuntimeError(this, "Cannot access method of non-object Value!");
-			return Value();
-		}
-		return vuh.t_value.as_object_ptr->get_property(interp, bk.name);
-	}
-	case(Handle::HType::Parent):
-	{
-		Value vuh = interp.get_property(fr.name, this);
-		if (vuh.t_vType != Value::vType::Object)
-		{
-			interp.RuntimeError(this, "Cannot access method of non-object Value!");
-			return Value();
-		}
-		return vuh.t_value.as_object_ptr->get_property(interp, bk.name);
-	}
-	}
+	Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(back)->get_str());
+	if (v) return *v;
 
 
-	interp.RuntimeError(this, "Unimplemented MemberAccess detected at runtime!");
-	return Value();
+	return Value(fr.t_value.as_object_ptr->get_method(interp, static_cast<Identifier*>(back)->get_str()));
 }
 
-Handle MemberAccess::handle(Interpreter& interp) // Tons of similar code to MemberAccess::resolve(). Could be merged somehow?
+Value& MemberAccess::handle(Interpreter& interp) // Tons of similar code to MemberAccess::resolve(). Could be merged somehow?
 {
-	Handle fr = front->handle(interp);
+	Value& fr = front->handle(interp);
+
+	if (fr.t_vType != Value::vType::Object)
+	{
+		interp.RuntimeError(this, "Attempted to do MemberAccess on non-Object Value!");
+		return *(new Value(Value::vType::Null, 1));
+	}
+
 	//Has to always be a plain string handle
-	Handle bk = back->handle(interp);
 
-	if (bk.type != Handle::HType::Name)
+	if (back->class_name() != "Identifier")
 	{
-		interp.RuntimeError(this, "Cannot do MemberAccess with non-string property name!");
-		return Handle();
-	}
-	if (fr.is_function)
-	{
-		interp.RuntimeError(this, "Illegal attempt to access members of a function or method!");
-		return Handle();
+		interp.RuntimeError(this, "Cannot access non-identifier member from Object!");
+		return *(new Value(Value::vType::Null, 1));
 	}
 
-	switch (fr.type)
-	{
-	default:
-		interp.RuntimeError(this, "Unknown or underimplemented HandleType used during MemberAccess!");
-	case(Handle::HType::Invalid):
-		return Handle();
-	case(Handle::HType::Name): // A localscoped name of an object
-	{
-		Value vuh = interp.get_var(fr.name, this);
-		if (vuh.t_vType != Value::vType::Object) // Has to be an object
-		{
-			interp.RuntimeError(this, "Cannot access method of non-object Value!");
-			return Handle();
-		}
-		/*
-		So we can't actually trust bk's understanding of whether or not it is a function,
-		since it may be a function of this object, but not visible in objectscope nor globalscope.
-
-		Honestly the whole Handle system right now is a bit hackish and could be improved to improve performance and reduce complexity;
-		definitely something to consider overhauling for v1.1 or v1.2.
-		*/
-
-		bk.is_function = vuh.t_value.as_object_ptr->get_method(interp, bk.name);
-
-		return Handle(vuh.t_value.as_object_ptr, bk.name, bk.is_function);
-
-	}
-	case(Handle::HType::Global): // A globalscope object
-	{
-		Value vuh = interp.get_global(fr.name, this);
-		if (vuh.t_vType != Value::vType::Object)
-		{
-			interp.RuntimeError(this, "Cannot access method of non-object Value!");
-			return Handle();
-		}
-		return Handle(vuh.t_value.as_object_ptr, bk.name, bk.is_function);
-	}
-	case(Handle::HType::Parent):
-	{
-		Value vuh = interp.get_property(fr.name, this);
-		if (vuh.t_vType != Value::vType::Object)
-		{
-			interp.RuntimeError(this, "Cannot access method of non-object Value!");
-			return Handle();
-		}
-		return Handle(vuh.t_value.as_object_ptr, bk.name, bk.is_function);
-	}
-	}
+	Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(back)->get_str());
+	if (v) return *v;
 
 
-	interp.RuntimeError(this, "Unimplemented MemberAccess detected at runtime!");
-	return Handle();
+	return *(new Value(fr.t_value.as_object_ptr->get_method(interp, static_cast<Identifier*>(back)->get_str())));
 
 }
 
@@ -1039,19 +857,23 @@ Value ParentAccess::resolve(Interpreter& interp)
 	return interp.get_property(prop,this);
 }
 
-Handle ParentAccess::handle(Interpreter& interp)
+Value& ParentAccess::handle(Interpreter& interp)
 {
-	Handle hdl;
-	hdl.name = prop;
-	hdl.type = Handle::HType::Parent;
-	return hdl;
+	Object* o = interp.get_objectscope();
+	if (!o)
+	{
+		interp.RuntimeError(this, "Cannot do ParentAccess in classless function!");
+		return *(new Value(Value::vType::Null, 1));
+	}
+
+	return *(o->has_property(interp,prop));
 }
 
 Value GrandparentAccess::resolve(Interpreter& interp)
 {
 	return interp.grand_property(depth, prop, this);
 }
-Handle GrandparentAccess::handle(Interpreter& interp)
+Value& GrandparentAccess::handle(Interpreter& interp)
 {
 /*
 	So we might be a function or a property.
@@ -1066,23 +888,16 @@ Value GlobalAccess::resolve(Interpreter& interp)
 	return interp.get_global(var, this);
 }
 
-Handle GlobalAccess::handle(Interpreter& interp)
+Value& GlobalAccess::handle(Interpreter& interp)
 {
-	Handle hdl;
-	hdl.name = var;
-	hdl.type = Handle::HType::Global;
-	return hdl;
+	return interp.get_global(var, this);
 }
 
 Value IndexAccess::resolve(Interpreter& interp)
 {
-	Handle h_lhs = container->handle(interp);
+	Value& lhs = container->handle(interp);
 	Value rhs = index->resolve(interp);
 
-	if (h_lhs.type != Handle::HType::Name)
-		interp.RuntimeError(this, "Indexing is not fully implemented in all grammatical circumstances!");
-
-	Value lhs = interp.get_var(h_lhs.name, this);
 	switch (lhs.t_vType)
 	{
 	default:
@@ -1104,31 +919,22 @@ Value IndexAccess::resolve(Interpreter& interp)
 			Table* la_table = static_cast<Table*>(obj);
 			return la_table->at(interp, rhs);
 		}
-		else
+
+		if (rhs.t_vType != Value::vType::String)
 		{
-			if (rhs.t_vType != Value::vType::String)
-			{
-				interp.RuntimeError(this, "Cannot index into an Object with a Value of type " + rhs.typestring() + "!");
-				return Value();
-			}
-			return obj->get_property(interp, *rhs.t_value.as_string_ptr);
+			interp.RuntimeError(this, "Cannot index into an Object with a Value of type " + rhs.typestring() + "!");
+			return Value();
 		}
-		
+
+		return obj->get_property(interp, *rhs.t_value.as_string_ptr);
 	}
 	}
 }
 
-Handle IndexAccess::handle(Interpreter& interp)
+Value& IndexAccess::handle(Interpreter& interp)
 {
-	Handle h_lhs = container->handle(interp);
+	Value& lhs = container->handle(interp);
 	Value rhs = index->resolve(interp);
-
-	if (h_lhs.type != Handle::HType::Name)
-	{
-		interp.RuntimeError(this, "Attempted illegal or underimplemented indexing operation!");
-	}
-
-	Value lhs = interp.get_var(h_lhs.name, this);
 
 	if (lhs.t_vType != Value::vType::Object) // FIXME: Allow for index-based setting of string data
 	{
@@ -1138,18 +944,6 @@ Handle IndexAccess::handle(Interpreter& interp)
 	Object* obj = lhs.t_value.as_object_ptr;
 	if(!obj->is_table())
 		return MemberAccess(container, index).handle(interp); //FIXME: This is so fucked up but it makes so much sense; main issue is that runtimes will report themselves strangely
-
-	switch (rhs.t_vType)
-	{
-	case(Value::vType::String):
-		return Handle(obj, *rhs.t_value.as_string_ptr);
-	case(Value::vType::Integer):
-	{
-		return Handle(static_cast<Table*>(obj), rhs.t_value.as_int);
-	}
-	default:
-		interp.RuntimeError(this, "Unexpected or underimplemented type for index into Table: " + rhs.typestring() + "!");
-		return Handle();
-	}
-
+	//So it's a table then
+	return static_cast<Table*>(obj)->at(interp, rhs);
 }

--- a/AST.cpp
+++ b/AST.cpp
@@ -945,5 +945,5 @@ Value& IndexAccess::handle(Interpreter& interp)
 	if(!obj->is_table())
 		return MemberAccess(container, index).handle(interp); //FIXME: This is so fucked up but it makes so much sense; main issue is that runtimes will report themselves strangely
 	//So it's a table then
-	return static_cast<Table*>(obj)->at(interp, rhs);
+	return static_cast<Table*>(obj)->at_ref(interp, rhs);
 }

--- a/AST.cpp
+++ b/AST.cpp
@@ -772,52 +772,148 @@ Value BreakStatement::resolve(Interpreter& interp)
 Value MemberAccess::resolve(Interpreter& interp)
 {
 	Value& fr = front->handle(interp);
-	
+
 	if (fr.t_vType != Value::vType::Object)
 	{
 		interp.RuntimeError(this, "Attempted to do MemberAccess on non-Object Value!");
 		return Value();
 	}
 
-	//Has to always be a plain string handle
-
-	if (back->class_name() != "Identifier")
+	return rresolve(interp, fr);
+}
+Value MemberAccess::rresolve(Interpreter& interp, Value& fr)
+{
+	if (back->class_name() == "MemberAccess") // This is chained member access, a.b.c.d
 	{
-		interp.RuntimeError(this, "Cannot access non-identifier member from Object!");
-		return Value();
+		//Then we're actually going to do something fancy via rhandle().
+		//Now, the AST actually generates this a little bit oddly, with the "b" identifier embedded as the second operand of the higher-up memberaccess
+		//fret not though; we can recover it and then pass it onwards down the MemberAccess chain.
+
+		MemberAccess* mback = static_cast<MemberAccess*>(back);
+
+		if (mback->front->class_name() != "Identifier")
+		{
+			interp.RuntimeError(this, "Unimplemented or illegal MemberAccess with second operand of type " + back->class_name() + "!");
+			return Value();
+		}
+
+		Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(mback->front)->get_str());
+		if (!v)
+		{
+			interp.RuntimeError(this, "MemberAccess failed because member '" + static_cast<Identifier*>(mback->front)->get_str() + "' does not exist!");
+			return Value();
+		}
+
+		return mback->rresolve(interp, *v); // Gross, recursion.
+	}
+	else if (back->class_name() == "IndexAccess") // Handles member-and-index access mixing, a.b.c[0]
+	{ // Similar vibes to the MemberAccess handler to be honest
+		IndexAccess* iback = static_cast<IndexAccess*>(back);
+
+		if (iback->container->class_name() != "Identifier")
+		{
+			interp.RuntimeError(this, "Unimplemented or illegal MemberAccess with second operand of type " + back->class_name() + "!");
+			return Value();
+		}
+
+		Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(iback->container)->get_str());
+		if (!v) // if not a real member
+		{
+			interp.RuntimeError(this, "IndexAccess failed because member '" + static_cast<Identifier*>(iback->container)->get_str() + "' does not exist in object!");
+			return Value();
+		}
+		else if (v->t_vType != Value::vType::Object && v->t_vType != Value::vType::String)
+		{
+			interp.RuntimeError(this, "IndexAccess failed because member '" + static_cast<Identifier*>(iback->container)->get_str() + "' is not an indexable Value!");
+			return Value();
+		}
+
+		return iback->rresolve(interp, *v); // Gross, recursion.
+	}
+	else if (back->class_name() == "Identifier")
+	{
+		Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(back)->get_str());
+		if (v) return *v;
+		return Value(fr.t_value.as_object_ptr->get_method(interp, static_cast<Identifier*>(back)->get_str()));
 	}
 
-	Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(back)->get_str());
-	if (v) return *v;
-
-
-	return Value(fr.t_value.as_object_ptr->get_method(interp, static_cast<Identifier*>(back)->get_str()));
+	// This is something confusing, then
+	interp.RuntimeError(this, "Unimplemented MemberAccess with second operand of type " + back->class_name() + "!");
+	return Value();
 }
 
 Value& MemberAccess::handle(Interpreter& interp) // Tons of similar code to MemberAccess::resolve(). Could be merged somehow?
 {
 	Value& fr = front->handle(interp);
-
+	return rhandle(interp, fr);
+}
+Value& MemberAccess::rhandle(Interpreter& interp, Value& fr) // Tons of similar code to MemberAccess::resolve(). Could be merged somehow?
+{
 	if (fr.t_vType != Value::vType::Object)
 	{
 		interp.RuntimeError(this, "Attempted to do MemberAccess on non-Object Value!");
 		return *(new Value(Value::vType::Null, 1));
 	}
 
-	//Has to always be a plain string handle
-
-	if (back->class_name() != "Identifier")
+	if (back->class_name() == "MemberAccess") // This is chained member access, a.b.c.d
 	{
-		interp.RuntimeError(this, "Cannot access non-identifier member from Object!");
-		return *(new Value(Value::vType::Null, 1));
+		//Then we're actually going to do something fancy via rhandle().
+		//Now, the AST actually generates this a little bit oddly, with the "b" identifier embedded as the second operand of the higher-up memberaccess
+		//fret not though; we can recover it and then pass it onwards down the MemberAccess chain.
+
+		MemberAccess* mback = static_cast<MemberAccess*>(back);
+
+		if (mback->front->class_name() != "Identifier")
+		{
+			interp.RuntimeError(this, "Unimplemented or illegal MemberAccess with second operand of type " + back->class_name() + "!");
+			return *(new Value(Value::vType::Null, 1));
+		}
+
+		Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(mback->front)->get_str());
+		if (!v)
+		{
+			interp.RuntimeError(this, "MemberAccess failed because member '" + static_cast<Identifier*>(mback->front)->get_str() + "' does not exist!");
+			return *(new Value(Value::vType::Null, 1));
+		}
+
+		return mback->rhandle(interp, *v); // Gross, recursion.
+	}
+	else if (back->class_name() == "IndexAccess") // Handles member-and-index access mixing, a.b.c[0]
+	{ // Similar vibes to the MemberAccess handler to be honest
+		IndexAccess* iback = static_cast<IndexAccess*>(back);
+
+		if (iback->container->class_name() != "Identifier")
+		{
+			interp.RuntimeError(this, "Unimplemented or illegal MemberAccess with second operand of type " + back->class_name() + "!");
+			return *(new Value(Value::vType::Null, 1));
+		}
+
+		Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(iback->container)->get_str());
+		if (!v) // if not a real member
+		{
+			interp.RuntimeError(this, "IndexAccess failed because member '" + static_cast<Identifier*>(iback->container)->get_str() + "' does not exist in object!");
+			return *(new Value(Value::vType::Null, 1));
+		}
+		else if (v->t_vType != Value::vType::Object && v->t_vType != Value::vType::String)
+		{
+			interp.RuntimeError(this, "IndexAccess failed because member '" + static_cast<Identifier*>(iback->container)->get_str() + "' is not an indexable Value!");
+			return *(new Value(Value::vType::Null, 1));
+		}
+
+		return iback->rhandle(interp, *v); // Gross, recursion.
+	}
+	else if (back->class_name() == "Identifier") 
+	{
+		Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(back)->get_str());
+		if (v) return *v;
+
+
+		return *(new Value(fr.t_value.as_object_ptr->get_method(interp, static_cast<Identifier*>(back)->get_str())));
 	}
 
-	Value* v = fr.t_value.as_object_ptr->has_property(interp, static_cast<Identifier*>(back)->get_str());
-	if (v) return *v;
-
-
-	return *(new Value(fr.t_value.as_object_ptr->get_method(interp, static_cast<Identifier*>(back)->get_str())));
-
+	// This is something confusing, then
+	interp.RuntimeError(this, "Unimplemented MemberAccess with second operand of type " + back->class_name() + "!");
+	return *(new Value(Value::vType::Null, 1));
 }
 
 std::unordered_map<std::string, Value> ClassDefinition::resolve_properties(Parser& parse)
@@ -893,9 +989,15 @@ Value& GlobalAccess::handle(Interpreter& interp)
 	return interp.get_global(var, this);
 }
 
+
+
 Value IndexAccess::resolve(Interpreter& interp)
 {
 	Value& lhs = container->handle(interp);
+	return rresolve(interp, lhs);
+}
+Value IndexAccess::rresolve(Interpreter& interp, Value& lhs)
+{
 	Value rhs = index->resolve(interp);
 
 	switch (lhs.t_vType)
@@ -934,6 +1036,10 @@ Value IndexAccess::resolve(Interpreter& interp)
 Value& IndexAccess::handle(Interpreter& interp)
 {
 	Value& lhs = container->handle(interp);
+	return rhandle(interp, lhs);
+}
+Value& IndexAccess::rhandle(Interpreter& interp, Value& lhs)
+{
 	Value rhs = index->resolve(interp);
 
 	if (lhs.t_vType != Value::vType::Object) // FIXME: Allow for index-based setting of string data
@@ -942,7 +1048,7 @@ Value& IndexAccess::handle(Interpreter& interp)
 	}
 
 	Object* obj = lhs.t_value.as_object_ptr;
-	if(!obj->is_table())
+	if (!obj->is_table())
 		return MemberAccess(container, index).handle(interp); //FIXME: This is so fucked up but it makes so much sense; main issue is that runtimes will report themselves strangely
 	//So it's a table then
 	return static_cast<Table*>(obj)->at_ref(interp, rhs);

--- a/AST.h
+++ b/AST.h
@@ -762,6 +762,7 @@ public:
 
 class MemberAccess final : public ASTNode
 {
+
 	ASTNode* front;
 	ASTNode* back;
 public:
@@ -774,8 +775,13 @@ public:
 	}
 
 	virtual Value resolve(Interpreter&) override;
+	Value rresolve(Interpreter&, Value&);
 
 	virtual Value& handle(Interpreter&) override;
+
+	//A special-snowflake thing for MemberAccess that helps it handle long, complex member access chains, like "a.b.c.d.e.f" and so on
+	//it treats the incoming Value ref as if it were its front node.
+	Value& rhandle(Interpreter&, Value&);
 
 	virtual const std::string class_name() const override { return "MemberAccess"; }
 	virtual std::string dump(int indent)
@@ -932,7 +938,11 @@ public:
 	}
 
 	virtual Value resolve(Interpreter&) override;
+	Value rresolve(Interpreter&, Value&);
 	virtual Value& handle(Interpreter&) override;
+
+	//See MemberAccess's similar function
+	Value& rhandle(Interpreter&, Value&);
 
 	virtual const std::string class_name() const override { return "IndexAccess"; }
 	virtual std::string dump(int indent) override

--- a/AST.h
+++ b/AST.h
@@ -28,6 +28,8 @@ public:
 		Function* as_function_ptr;
 	}t_value;
 
+	static Value dev_null;
+
 	//Constructors
 	Value()
 	{

--- a/AST.h
+++ b/AST.h
@@ -775,13 +775,7 @@ public:
 	}
 
 	virtual Value resolve(Interpreter&) override;
-	Value rresolve(Interpreter&, Value&);
-
 	virtual Value& handle(Interpreter&) override;
-
-	//A special-snowflake thing for MemberAccess that helps it handle long, complex member access chains, like "a.b.c.d.e.f" and so on
-	//it treats the incoming Value ref as if it were its front node.
-	Value& rhandle(Interpreter&, Value&);
 
 	virtual const std::string class_name() const override { return "MemberAccess"; }
 	virtual std::string dump(int indent)
@@ -938,11 +932,7 @@ public:
 	}
 
 	virtual Value resolve(Interpreter&) override;
-	Value rresolve(Interpreter&, Value&);
 	virtual Value& handle(Interpreter&) override;
-
-	//See MemberAccess's similar function
-	Value& rhandle(Interpreter&, Value&);
 
 	virtual const std::string class_name() const override { return "IndexAccess"; }
 	virtual std::string dump(int indent) override

--- a/Interpreter.cpp
+++ b/Interpreter.cpp
@@ -138,7 +138,7 @@ Value& Interpreter::get_var(std::string varname, ASTNode *getter)
 
 	//Give up :(
 	RuntimeError(getter,"Unable to access variable named " + varname + "!");
-	return *(new Value(Value::vType::Null, 1));; // memory leak woooo
+	return Value::dev_null;
 }
 
 Function* Interpreter::get_func(std::string funkname, ASTNode *caller, bool loud)
@@ -232,7 +232,7 @@ Value& Interpreter::grand_handle(unsigned int depth, std::string str, ASTNode* g
 	if (!obj)
 	{
 		RuntimeError(getter, "Cannot get grandparent handle in classless objectscope!");
-		return *(new Value(Value::vType::Null, 1));
+		return Value::dev_null;
 	}
 
 	std::string dir = obj->object_type;
@@ -244,13 +244,13 @@ Value& Interpreter::grand_handle(unsigned int depth, std::string str, ASTNode* g
 	if (dir == "/")
 	{
 		RuntimeError(getter, "Attempted to get grandparent handle of root directory!");
-		return *(new Value(Value::vType::Null, 1));
+		return Value::dev_null;
 	}
 
 	if (!prog->definedObjTypes.count(dir))
 	{
 		RuntimeError(getter, "Failed to find objecttype of type " + dir + " during handle() of GrandparentAccess!"); // This'll be a weird error to get once inheritence is functional
-		return *(new Value(Value::vType::Null, 1));
+		return Value::dev_null;
 	}
 
 	ObjectType* objt = prog->definedObjTypes.at(dir);
@@ -270,7 +270,7 @@ Value& Interpreter::grand_handle(unsigned int depth, std::string str, ASTNode* g
 	}
 
 	RuntimeError(getter, "Failed to get property of Parent objectscope!");
-	return *(new Value(Value::vType::Null, 1));
+	return Value::dev_null;
 }
 
 Value Interpreter::makeObject(std::string str, std::vector<ASTNode*>& args, ASTNode* maker)

--- a/Interpreter.cpp
+++ b/Interpreter.cpp
@@ -53,7 +53,7 @@ void Interpreter::RuntimeError(ASTNode* a, std::string what)
 	}
 	
 	std::cout << "Line number: ";
-	if(a->my_line)
+	if(a && a->my_line)
 	{
 		std::cout << std::to_string(a->my_line);
 	}

--- a/Interpreter.h
+++ b/Interpreter.h
@@ -86,11 +86,27 @@ public:
 		objectscope.pop();
 	}
 
+	//Like get_global but returns the pointer instead, and quietly allocates a new global when you ask for one it hasn't seen before.
+	Value* has_global(std::string name, ASTNode* getter)
+	{
+		if (!globalscope.table.count(name))
+		{
+			globalscope.table[name] = new Value();
+			return globalscope.table[name];
+		}
+
+		return globalscope.table.at(name);
+	}
 
 	Value& get_global(std::string name, ASTNode* getter)
 	{
 		if (!globalscope.table.count(name))
-			RuntimeError(getter, "Unable to access global value: " + name);
+		{
+			RuntimeError(getter, "Unable to access global value: " + name); // Works, just returns null and yells.
+			globalscope.table[name] = new Value();
+			return *globalscope.table[name];
+		}
+			
 		return *globalscope.table.at(name);
 	}
 	void set_global(std::string name, Value& val, ASTNode* setter)

--- a/Interpreter.h
+++ b/Interpreter.h
@@ -40,14 +40,16 @@ public:
 	//Override the value of an already-existing variable at the lowest scope available.
 	void override_var(std::string, Value, ASTNode*);
 	//Get variable at the lowest scope available.
-	Value get_var(std::string, ASTNode*);
+	Value& get_var(std::string, ASTNode*);
 	bool has_var(std::string, ASTNode*);
 
+
+	Object* get_objectscope() const { return objectscope.top(); }
 	///Objectscope
 	Value get_property(std::string, ASTNode*);
 	void set_property(std::string, Value, ASTNode*);
 	Value grand_property(unsigned int, std::string, ASTNode*);
-	Handle grand_handle(unsigned int, std::string, ASTNode*);
+	Value& grand_handle(unsigned int, std::string, ASTNode*);
 
 	//Construct an object and return it as a Value.
 	Value makeObject(std::string,std::vector<ASTNode*>&,ASTNode*);
@@ -85,7 +87,7 @@ public:
 	}
 
 
-	Value get_global(std::string name, ASTNode* getter)
+	Value& get_global(std::string name, ASTNode* getter)
 	{
 		if (!globalscope.table.count(name))
 			RuntimeError(getter, "Unable to access global value: " + name);

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -874,6 +874,7 @@ std::vector<Expression*> Parser::readBlock(BlockType bt, int here, int there) //
 		}
 		case(Token::cEnum::WordToken):
 		case(Token::cEnum::DirectoryToken):
+		case(Token::cEnum::ParentToken):
 		//If the Grammar serves me right, this is either a varstat or a functioncall.
 		//The main way to disambiguate is to check if the var_access is if any assignment operation takes place on this line.
 		{

--- a/Table.cpp
+++ b/Table.cpp
@@ -39,7 +39,7 @@ Value& Table::at_ref(Interpreter& interp, Value index)
 	{
 	default:
 		interp.RuntimeError(nullptr, "Bad type used to index into Table!");
-		return *(new Value(Value::vType::Null, 1));
+		return Value::dev_null;
 	case(Value::vType::String): // Just use our properties, innit?
 		return *(has_property(interp, *index.t_value.as_string_ptr));
 	case(Value::vType::Integer):

--- a/Table.cpp
+++ b/Table.cpp
@@ -1,7 +1,7 @@
 #include "Table.h"
 #include "Interpreter.h"
 
-Value Table::at(Interpreter& interp, Value index)
+Value& Table::at(Interpreter& interp, Value index)
 {
 	Value::JoaoInt array_index;
 
@@ -9,9 +9,9 @@ Value Table::at(Interpreter& interp, Value index)
 	{
 	default:
 		interp.RuntimeError(nullptr, "Bad type used to index into Table!");
-		return Value();
+		return *(new Value(Value::vType::Null, 1));
 	case(Value::vType::String): // Just use our properties, innit?
-		return get_property(interp, *index.t_value.as_string_ptr);
+		return *(has_property(interp, *index.t_value.as_string_ptr));
 	case(Value::vType::Integer):
 		array_index = index.t_value.as_int;
 		break;
@@ -25,10 +25,10 @@ Value Table::at(Interpreter& interp, Value index)
 	if (array_index < 0 || array_index >= static_cast<Value::JoaoInt>(t_array.size()))
 	{
 		interp.RuntimeError(nullptr, "Index was out-of-bounds of array!");
-		return Value();
+		return *(new Value(Value::vType::Null, 1));
 	}
 
-	return t_array[array_index];
+	return t_array.at(array_index);
 }
 
 void Table::at_set(Interpreter& interp, Value index, Value& newval)

--- a/Table.cpp
+++ b/Table.cpp
@@ -1,7 +1,37 @@
 #include "Table.h"
 #include "Interpreter.h"
 
-Value& Table::at(Interpreter& interp, Value index)
+Value Table::at(Interpreter& interp, Value index)
+{
+	Value::JoaoInt array_index;
+
+	switch (index.t_vType)
+	{
+	default:
+		interp.RuntimeError(nullptr, "Bad type used to index into Table!");
+		return Value();
+	case(Value::vType::String): // Just use our properties, innit?
+		return *(has_property(interp, *index.t_value.as_string_ptr));
+	case(Value::vType::Integer):
+		array_index = index.t_value.as_int;
+		break;
+	case(Value::vType::Double): //Dude. You can't use a raw-ass double to index. That's fucking stupid. You're stupid.
+		//I'm rounding this while glaring at you sternly.
+		array_index = math::round({ index }).t_value.as_int;
+		break;
+	}
+	//Should be able to safely assert by this point that array_index has been set to something.
+
+	if (array_index < 0 || array_index >= static_cast<Value::JoaoInt>(t_array.size()))
+	{
+		interp.RuntimeError(nullptr, "Index was out-of-bounds of array!");
+		return Value();
+	}
+
+	return t_array.at(array_index);
+}
+
+Value& Table::at_ref(Interpreter& interp, Value index)
 {
 	Value::JoaoInt array_index;
 
@@ -22,10 +52,9 @@ Value& Table::at(Interpreter& interp, Value index)
 	}
 	//Should be able to safely assert by this point that array_index has been set to something.
 
-	if (array_index < 0 || array_index >= static_cast<Value::JoaoInt>(t_array.size()))
+	if (array_index >= static_cast<Value::JoaoInt>(t_array.size()))
 	{
-		interp.RuntimeError(nullptr, "Index was out-of-bounds of array!");
-		return *(new Value(Value::vType::Null, 1));
+		resize(array_index);
 	}
 
 	return t_array.at(array_index);
@@ -71,7 +100,7 @@ void Table::at_set(Interpreter& interp, Value index, Value& newval)
 
 	if (array_index >= static_cast<Value::JoaoInt>(t_array.size()))
 	{
-		t_array.resize(static_cast<size_t>(array_index) + 1, Value()); // FIXME: this is fucking crazy and needs to be changed so as to better support sparsely-populated arrays
+		resize(array_index);
 	}
 	t_array[array_index] = newval;
 }

--- a/Table.h
+++ b/Table.h
@@ -27,9 +27,20 @@ public:
 
 	}
 
+	//Returns the value stored at this index, or NULL and a runtime if it cannot be found.
+	Value at(Interpreter&, Value);
+	
+	//Gets a handle to the value pointed to by this index. Quietly creates a reference to a null Value if it cannot be found.
+	Value& at_ref(Interpreter&, Value);
 
-	Value& at(Interpreter&, Value);
+	//Sets the value pointed to by index to the value referenced by the second.
 	void at_set(Interpreter&, Value, Value&);
+
+	//Handle a resize of the array such that it can now store new_index.
+	void resize(Value::JoaoInt new_index)
+	{
+		t_array.resize(static_cast<size_t>(new_index) + 1, Value()); // FIXME: this is fucking crazy and needs to be changed so as to better support sparsely-populated arrays
+	}
 
 	size_t length() { return t_array.size(); }
 	bool virtual is_table() override { return true; }

--- a/Table.h
+++ b/Table.h
@@ -28,7 +28,7 @@ public:
 	}
 
 
-	Value at(Interpreter&, Value);
+	Value& at(Interpreter&, Value);
 	void at_set(Interpreter&, Value, Value&);
 
 	size_t length() { return t_array.size(); }


### PR DESCRIPTION
This refactors a lot of how references are handled in general, ditching a crappy class in favour of just using ``Value&`` for simplicity's sake.

I'm not 100% convinced that this is bugless but it seems to be working so far, for what that's worth.