### PR TITLE
Reengineers how Table allocates stuff

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -45,3 +45,4 @@ jobs:
         ./x64/Release/Joao.exe ./testprograms/tests/5_strings.jao
         ./x64/Release/Joao.exe ./testprograms/tests/6_parser.jao
         ./x64/Release/Joao.exe ./testprograms/tests/7_rvalues.jao
+        ./x64/Release/Joao.exe ./testprograms/tests/8_tablelib.jao

--- a/Table.cpp
+++ b/Table.cpp
@@ -59,6 +59,13 @@ Value& Table::at_ref(Interpreter& interp, Value index)
 		{
 			return t_hash.at(hash);
 		}
+#ifdef JOAO_SAFE
+		++interp.value_init_count;
+		if (interp.value_init_count > MAX_VARIABLES)
+		{
+			throw error::max_variables(std::string("Program reached the limit of ") + std::to_string(MAX_VARIABLES) + std::string("instantiated variables!"));
+		}
+#endif
 		return talloc(index, Value());
 	}
 	case(Value::vType::Integer):
@@ -78,6 +85,13 @@ Value& Table::at_ref(Interpreter& interp, Value index)
 		{
 			return t_hash.at(hash);
 		}
+#ifdef JOAO_SAFE
+		++interp.value_init_count;
+		if (interp.value_init_count > MAX_VARIABLES)
+		{
+			throw error::max_variables(std::string("Program reached the limit of ") + std::to_string(MAX_VARIABLES) + std::string("instantiated variables!"));
+		}
+#endif
 		return talloc(index, Value());
 	}
 

--- a/Table.cpp
+++ b/Table.cpp
@@ -41,7 +41,14 @@ Value& Table::at_ref(Interpreter& interp, Value index)
 		interp.RuntimeError(nullptr, ErrorCode::BadMemberAccess, "Bad type used to index into Table!");
 		return Value::dev_null;
 	case(Value::vType::String): // Just use our properties, innit?
-		return *(has_property(interp, *index.t_value.as_string_ptr));
+	{
+		size_t hash = std::hash<std::string>()(*index.t_value.as_string_ptr);
+		if (t_hash.count(hash))
+		{
+			return t_hash.at(hash);
+		}
+		return Value::dev_null;
+	}
 	case(Value::vType::Integer):
 		array_index = index.t_value.as_int;
 		break;
@@ -52,9 +59,14 @@ Value& Table::at_ref(Interpreter& interp, Value index)
 	}
 	//Should be able to safely assert by this point that array_index has been set to something.
 
-	if (array_index >= static_cast<Value::JoaoInt>(t_array.size()))
+	if (array_index < 0 || array_index >= static_cast<Value::JoaoInt>(t_array.size()))
 	{
-		resize(array_index);
+		size_t hash = std::hash<Value::JoaoInt>()(index.t_value.as_int);
+		if (t_hash.count(hash))
+		{
+			return t_hash.at(hash);
+		}
+		return Value::dev_null;
 	}
 
 	return t_array.at(array_index);
@@ -69,19 +81,14 @@ void Table::at_set(Interpreter& interp, Value index, Value& newval)
 	default:
 		interp.RuntimeError(nullptr, ErrorCode::BadMemberAccess, "Bad type used to index into Table!");
 		return;
-	case(Value::vType::String): // Just use our properties, innit?
+	case(Value::vType::String): 
 	{
-		//Should be analogous to set_property, except it *makes no check as to whether this property is something our ObjectType has*!!
-		std::string str = *index.t_value.as_string_ptr;
-		if (properties.count(str))
-		{
-			properties.erase(str);
-			properties[str] = newval;
-		}
-		else
-		{
-			properties[str] = newval;
-		}
+		// Unfortunately we can't just use our properties since, since these elements are removable,
+		// this would allow Objects which inherit from /table to rescind their properties and go AWOL from the OOP structure,
+		// which, while pleasantly chaotic, would be a horrible paradigm to allow, and honestly would probably end up being kinda buggy.
+		
+		size_t hash_index = std::hash<std::string>()(*index.t_value.as_string_ptr);
+		t_hash[hash_index] = newval;
 		return;
 	}
 	case(Value::vType::Integer):
@@ -94,13 +101,58 @@ void Table::at_set(Interpreter& interp, Value index, Value& newval)
 
 	if (array_index < 0)
 	{
-		interp.RuntimeError(nullptr, ErrorCode::BadMemberAccess, "Index cannot be negative in this implementation!"); //FIXME: Soon.
+		size_t hash_index = std::hash<Value::JoaoInt>()(index.t_value.as_int);
+		t_hash[hash_index] = newval;
 		return;
 	}
 
-	if (array_index >= static_cast<Value::JoaoInt>(t_array.size()))
-	{
-		resize(array_index);
+	//Would this fit in the next sequential spot?
+	if (array_index == static_cast<Value::JoaoInt>(t_array.size()))
+	{ // Perfect! A pleasant and surprisingly common case.
+		t_array.push_back(newval);
+		return;
 	}
-	t_array[array_index] = newval;
+
+	//Is this index already in the array to begin with?
+	if (array_index < static_cast<Value::JoaoInt>(t_array.size()))
+	{
+		t_array.at(array_index) = newval;
+		return;
+	}
+
+	//..Is this index already in the HASHTABLE to begin with?
+	size_t hash_index = std::hash<Value::JoaoInt>()(array_index);
+	if (t_hash.count(hash_index))
+	{
+		t_hash.at(hash_index) = newval;
+		return;
+	}
+
+	//If we won't cause a rehash by adding this new element to the hashtable...
+	if (static_cast<float>((t_hash.size() + 1)) / t_hash.bucket_count() < t_hash.max_load_factor())
+	{
+		// Just stick it in there, then, tbh
+		t_hash[hash_index] = newval;
+		return;
+	}
+
+	//If we *would*, do a check to make sure that we can't just move some stuff over
+
+	for (Value::JoaoInt i = t_array.size(); i < array_index; ++i)
+	{
+		size_t hash = std::hash<Value::JoaoInt>()(i);
+		if (!t_hash.count(hash))
+			goto JUST_HASH_IT;
+	}
+	//Oh god, we can actually do this.
+	for (Value::JoaoInt i = t_array.size(); i < array_index; ++i)
+	{
+		size_t hash = std::hash<Value::JoaoInt>()(i);
+		t_array.push_back(std::move(t_hash.at(hash)));
+		t_hash.erase(hash);
+	}
+
+JUST_HASH_IT:
+	t_hash[hash_index] = newval;
+	return;
 }

--- a/Table.h
+++ b/Table.h
@@ -21,6 +21,7 @@ class Table final : public Object
 {
 public:
 	std::vector<Value> t_array;
+	std::unordered_map<size_t, Value> t_hash;
 	Table(std::string objty, std::unordered_map<std::string, Value>* puh, std::unordered_map<std::string, Function*>* fuh)
 		:Object(objty,puh,fuh,nullptr)
 	{
@@ -35,12 +36,7 @@ public:
 
 	//Sets the value pointed to by index to the value referenced by the second.
 	void at_set(Interpreter&, Value, Value&);
-
-	//Handle a resize of the array such that it can now store new_index.
-	void resize(Value::JoaoInt new_index)
-	{
-		t_array.resize(static_cast<size_t>(new_index) + 1, Value()); // FIXME: this is fucking crazy and needs to be changed so as to better support sparsely-populated arrays
-	}
+	bool at_set_raw(Value, Value&);
 
 	size_t length() { return t_array.size(); }
 	bool virtual is_table() override { return true; }

--- a/Table.h
+++ b/Table.h
@@ -19,6 +19,10 @@ This concept in general is a mixture of general OOP and Lua's concept of having 
 */
 class Table final : public Object
 {
+	//The worker function for at_ref, at_set, and at_set_raw.
+	//Allocates space within the table for the key-value pair corresponding to the 1st and 2nd args, respectively.
+	//Returns a reference to the place it allocated. Must succeed.
+	Value& talloc(Value, const Value&);
 public:
 	std::vector<Value> t_array;
 	std::unordered_map<size_t, Value> t_hash;

--- a/Table.h
+++ b/Table.h
@@ -24,6 +24,9 @@ class Table final : public Object
 	//Returns a reference to the place it allocated. Must succeed.
 	Value& talloc(Value, const Value&);
 public:
+	//Deallocates the index provided, if it exists somewhere.
+	void tfree(const Value&);
+
 	std::vector<Value> t_array;
 	std::unordered_map<size_t, Value> t_hash;
 	Table(std::string objty, std::unordered_map<std::string, Value>* puh, std::unordered_map<std::string, Function*>* fuh)

--- a/Value.cpp
+++ b/Value.cpp
@@ -135,6 +135,9 @@ std::string Value::typestring()
 
 Value& Value::operator=(const Value& rhs)
 {
+	if (this == &Value::dev_null)
+		return *this;
+
 	if (this == &rhs)
 		return *this;
 

--- a/nativefuncs/tablelib.cpp
+++ b/nativefuncs/tablelib.cpp
@@ -72,26 +72,69 @@ ObjectType* Program::construct_table_library()
 			return Value(args[rand() % args.size()]);
 		});
 
+	table->set_typemethod_raw("insert", new NativeMethod("remove", [](std::vector<Value> args, Object* obj) {
+		if (args.size() < 2)
+			return Value(Value::vType::Null, int(ErrorCode::NotEnoughArgs));
+		const Value& vindex = args[0];
+		Value::JoaoInt index = 0;
+		Table* table = static_cast<Table*>(obj);
+		switch (vindex.t_vType)
+		{
+		default:
+			return Value(Value::vType::Null, int(ErrorCode::BadArgType));
+		case(Value::vType::Double):
+			index = math::round({ vindex.t_value.as_double }).t_value.as_int;
+			[[fallthrough]];
+		case(Value::vType::Integer):
+			index = index || vindex.t_value.as_int; // Best I could come up with
+			//Since we're in /table/insert(), and not Table::at_set() or whatever,
+			//We have to make a point of, like, actually inserting into t_array if necessary.
+			if (index >= 0)
+			{
+				auto& arr = table->t_array;
+				if (index < arr.size()) // if we're trying to insert at a place where an element already exists
+				{
+					auto& hash = table->t_hash;
+					//Before we do this, imagine that there's an index [9] present in the hashtable, and the array only goes from [0] to [8].
+					//Inserting naïvely in that case would clobber the 9th element, which is a bad.
+
+					//talloc() tries to prevent this, but it's still possible, so lets do some checks first.
+					while (hash.count(std::hash<Value::JoaoInt>()(arr.size()))) // If this is the case
+					{ // take that element and actually put it on the fucking array, I guess
+						Value::JoaoInt hash_index = std::hash<Value::JoaoInt>()(arr.size());
+						arr.push_back(std::move(hash.at(hash_index)));
+						hash.erase(hash_index);
+					}
+
+					arr.insert(arr.begin() + index, args[1]);
+					return Value(); // Skips a lot of the silliness of talloc(), which is nice, even if insert() is expensive.
+				}
+			}
+			//Otherwise, fallthrough to just using talloc() like normal.
+			[[fallthrough]];
+		case(Value::vType::String):
+			if (table->at_set_raw(vindex, args[1]))
+			{
+				return Value(Value::vType::Null, int(ErrorCode::FailedOperation)); // I'unno.
+			}
+			return Value();
+		}
+	}));
+
 	table->set_typemethod_raw("remove",new NativeMethod("remove",[](std::vector<Value> args, Object* obj){
 		if(args.size() < 1)
 			return Value(Value::vType::Null, int(ErrorCode::NotEnoughArgs));
-		if(args[0].t_vType != Value::vType::Integer)
-			return Value(Value::vType::Null, int(ErrorCode::BadArgType));
-		
-		size_t index = args[0].t_value.as_int;
-
-		//This tries to mimic some of the behavior of at_set() w/o explicitly calling it
-		//FIXME: This should really all use the same function tbh
-
-		Table* t = static_cast<Table*>(obj);
-
-		if(index >= t->t_array.size())
+		const Value& vindex = args[0];
+		switch (vindex.t_vType)
 		{
+		default:
+			return Value(Value::vType::Null, int(ErrorCode::BadArgType));
+		case(Value::vType::Integer):
+		case(Value::vType::String):
+		case(Value::vType::Double):
+			static_cast<Table*>(obj)->tfree(vindex);
 			return Value();
 		}
-
-		t->t_array.erase(t->t_array.begin() + index);
-		return Value();
 	}));
 
 	return table;

--- a/nativefuncs/tablelib.cpp
+++ b/nativefuncs/tablelib.cpp
@@ -72,7 +72,7 @@ ObjectType* Program::construct_table_library()
 			return Value(args[rand() % args.size()]);
 		});
 
-	table->set_typemethod_raw("insert", new NativeMethod("remove", [](std::vector<Value> args, Object* obj) {
+	table->set_typemethod_raw("insert", new NativeMethod("insert", [](std::vector<Value> args, Object* obj) {
 		if (args.size() < 2)
 			return Value(Value::vType::Null, int(ErrorCode::NotEnoughArgs));
 		const Value& vindex = args[0];

--- a/nativefuncs/tablelib.cpp
+++ b/nativefuncs/tablelib.cpp
@@ -56,36 +56,6 @@ ObjectType* Program::construct_table_library()
 		return Value(result);
 	}));
 
-
-	table->set_typemethod_raw("insert",new NativeMethod("insert",[](std::vector<Value> args, Object* obj){
-		if(args.size() < 2)
-			return Value(Value::vType::Null, int(ErrorCode::NotEnoughArgs));
-		if(args[0].t_vType != Value::vType::Integer)
-			return Value(Value::vType::Null, int(ErrorCode::BadArgType));
-		
-		size_t index = args[0].t_value.as_int;
-
-		//This tries to mimic some of the behavior of at_set() w/o explicitly calling it
-		//FIXME: This should really all use the same function tbh
-
-		Table* t = static_cast<Table*>(obj);
-
-		if(index > t->t_array.size())
-		{
-			t->t_array.resize(index,Value());
-			t->t_array.push_back(args[1]);
-		}
-		else if(index ==  t->t_array.size())
-		{
-			t->t_array.push_back(args[1]);
-		}
-		else
-		{
-			t->t_array.insert(t->t_array.begin() + index,args[1]);
-		}
-		return Value();
-	}));
-
 	table->set_typemethod_raw("pick", new NativeMethod("pick", [](std::vector<Value> args, Object* obj) {
 		Table* t = static_cast<Table*>(obj);
 

--- a/testprograms/tests/8_tablelib.jao
+++ b/testprograms/tests/8_tablelib.jao
@@ -1,0 +1,32 @@
+/main()
+{
+	Number TEST_NUMBER = 8;
+	
+	Object t = /table/New();
+	
+	t.insert(0,"bet");
+	t.insert(0,"Alpha");
+	if(t[0] .. t[1] != "Alphabet")
+	{
+		throw /error/New(TEST_NUMBER,"/table.insert failed!");
+	}
+	Object t2 = t;
+	if(t2[0] != t[0])
+	{
+		throw /error/New(TEST_NUMBER,"Table copy-by-reference failed!");
+	}
+	t[3] = " to learn";
+	t[2] = " is easy";
+	if(t[0] .. t[1] .. t[2] .. t[3] != "Alphabet is easy to learn")
+	{
+		throw /error/New(TEST_NUMBER,"Non sequitur index assignment failed!");
+	}
+	t.remove(2); ## Especially tests removing an element along the array/hash border
+	if(t[0] .. t[1] .. t[2] != "Alphabet to learn")
+	{
+		print(t[0] .. t[1] .. t[2],"!=","Alphabet to learn");
+		throw /error/New(TEST_NUMBER,"/table.remove failed!");
+	}
+	
+	print("Test #" .. TEST_NUMBER .. " passed");
+}


### PR DESCRIPTION
The current implementation for ``/table`` is extremely dubious.

There's bugs in removing string-indexed elements, but beyond that, it has the lovely behaviour that, when you attempt to index with a very large index (such as a million), it will genuinely allocate one million elements of space for the ``/table`` just so it can fit it in the ``std::vector`` it has. Bollocks.

## Changelog
- Fixed ``/table`` allocating ridiculous amounts of memory when given large numeric indices
- Fixed ``/table`` not supporting negative integer/double indices
- Fixed string-indexed values in ``/table``s being unremovable
- Fixed ``Value::dev_null`` hypothetically preserving a Value which doesn't exist anywhere else.
- Fixed ``/table.remove()`` and ``/table.insert()`` not supporting indices that weren't positive integers.
- Fixed ``JOAO_SAFE`` not detecting new indexes in arrays as novel variables to be counted.