### PR TITLE
Implements the concept of "mass concatenation" with a new, specialized ASTNode

### DIFF
--- a/AST.cpp
+++ b/AST.cpp
@@ -751,3 +751,19 @@ Value ThrowStatement::resolve(Interpreter& interp)
 
 	return Value(); // If anything.
 }
+
+Value MassConcatenation::resolve(Interpreter& interp)
+{
+#ifdef JOAO_SAFE
+	size_t opsize = operands.size();
+	for(size_t i = 0; i < opsize; ++i)
+		increment();
+#endif
+	std::string& ret = *(new std::string());
+	ret.reserve(estimated_evaluated_size);
+	for (ASTNode* nodeptr : operands)
+	{
+		ret.append(nodeptr->resolve(interp).to_string());
+	}
+	return Value(&ret);
+}

--- a/AST.h
+++ b/AST.h
@@ -39,6 +39,7 @@ public:
 	{
 		//std::cout << "Constructing literal...\n";
 	}
+	const Value& value() const { return heldval; }
 
 	virtual Value resolve(Interpreter&) override;
 	virtual Value const_resolve(Parser&, bool) override;
@@ -982,10 +983,31 @@ class MassConcatenation : public Expression
 {
 	std::vector<ASTNode*> operands; // AFAIK the vector can't store them itself since they're derived types of unknown size; would get "demoted" implicitly
 	const size_t estimated_evaluated_size; // A guess at how big the resulting string will be after concatenation. Used to minimize mallocs.
+	size_t calculate_estimated_size()
+	{
+		size_t i = 0;
+		for (ASTNode* node : operands)
+		{
+			if (node->class_name() == "Literal")
+			{
+				Literal* litnode = static_cast<Literal*>(node);
+				i += litnode->value().to_string().size();
+				continue;
+			}
+			i += 16; //FIXME: This is such a ballpark, out-of-my-ass estimate. Be better about predicting result size.
+		}
+#if defined(LOUD_AST) && !defined(JOAO_SAFE)
+		if (i == 0)
+		{
+			std::cout << "WARNING: MassConcatenation determined estimated size to be zero!\n";
+		}
+#endif
+		return i;
+	}
 public:
 	MassConcatenation(const std::vector<ASTNode*>& ops)
 		:operands(ops)
-		,estimated_evaluated_size(operands.size() * 16) //FIXME: This is such a ballpark, out-of-my-ass estimate. Be better about predicting result size.
+		,estimated_evaluated_size(calculate_estimated_size())
 	{
 
 	}

--- a/Value.h
+++ b/Value.h
@@ -174,6 +174,25 @@ public:
 		}
 		t_vType = vType::String;
 	}
+	//A special-snowflake optimization where somebody else has already allocated this string onto the heap
+	//(and so it doesn't need to be copied onto the heap from the stack or where-ever the fuck)
+	//DO NOT GIVE THIS CONSTRUCTOR POINTERS TO MEMORY ON THE STACK. THIS CLASS WILL ATTEMPT TO DELETE THEM LATER.
+	Value(std::string* const sptr)
+	{
+		if (cached_ptrs.count(sptr) == 0) // Novel string, it seems!
+		{
+			t_value.as_string_ptr = sptr;
+			cached_ptrs[sptr] = 1u;
+			str_to_ptr[*sptr] = sptr; //FIXME: This is still a string copy. Can we make it better?
+		}
+		else
+		{
+			t_value.as_string_ptr = sptr;
+			cached_ptrs[sptr]++;
+		}
+		t_vType = vType::String;
+	}
+
 	Value(Object* o);
 	
 	//Jesus fucking christ I wish the copy-move-reference tricohotomy made any fucking sense in C++

--- a/Value.h
+++ b/Value.h
@@ -179,16 +179,18 @@ public:
 	//DO NOT GIVE THIS CONSTRUCTOR POINTERS TO MEMORY ON THE STACK. THIS CLASS WILL ATTEMPT TO DELETE THEM LATER.
 	Value(std::string* const sptr)
 	{
-		if (cached_ptrs.count(sptr) == 0) // Novel string, it seems!
+		if (str_to_ptr.count(*sptr) == 0) // Novel string, it seems!
 		{
 			t_value.as_string_ptr = sptr;
 			cached_ptrs[sptr] = 1u;
 			str_to_ptr[*sptr] = sptr; //FIXME: This is still a string copy. Can we make it better?
 		}
-		else
-		{
-			t_value.as_string_ptr = sptr;
-			cached_ptrs[sptr]++;
+		else // This is an awkward circumstance where the string ref counter already has an equivalent string set up.
+		{    // In such case, we delete the pointer given and make this Value direct to that already-existant pointer.
+			std::string* real_ptr = str_to_ptr.at(*sptr);
+			t_value.as_string_ptr = real_ptr;
+			cached_ptrs[real_ptr]++;
+			delete sptr;
 		}
 		t_vType = vType::String;
 	}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/152908134-878e8dbb-a20b-4b88-a16c-0ac4e65a7ffb.png)


One common issue with most implementations of a concatenation operator is that it's left-associative and sequential, just like any typical operator. ``A .. B .. C .. D`` allocates into memory A, then AB, then ABC, then ABCD, on and on. For very long runs of successive concatenation, this can cause very large and unnecessary reallocation events for each iteration of the process.

This patch changes the behaviour of these to forgo the typical behaviour of binary operations in favour of a "single-batch" approach, where each operand is evaluated and appended to a master string, with the goal of making the number of allocations at least semi-linear with the number of operands.

I'm not wholly satisfied with this implementation, but it's a good step towards reducing the amount of redundant malloc/free calls currently littering the João project at the moment.

This PR made this script run twice as fast compared to the ``main`` branch:
```php
/main(args)
{
    for(Value i = 0; i < 100_000; i+=1)
    {
        String str = "This index is called '" .. i .. ", and twice its value is " .. i * 2 .. "!";
        ##print(str);
    }
}
```